### PR TITLE
Python script updated

### DIFF
--- a/preparing_for_analysis.py
+++ b/preparing_for_analysis.py
@@ -1,4 +1,6 @@
 """
+Author: Jakub Dotlacil
+
 This script takes a json file from the mouse tracking experiment.
 It outputs four files:
 


### PR DESCRIPTION
The python script:

1. Allows to specify cutoff points to remove very short mouse fixations. Mouse fixations shorter than the cutoff point will be removed and the calculation of first/second pass will be calculated without those mouse fixations.
2. Corrects a mistake in calculating first and second pass. In the original version, if a reader regressed from word n and came back to the same word n, the second time would be labeled as second pass. It should still be first pass. To signal that this is first pass after regression, I labeled it as "first pass again".
3. Some small cleanups for calling the script.
